### PR TITLE
Fix/#31 username 수정 로직 제거

### DIFF
--- a/src/main/java/com/fitnesspartner/domain/Users.java
+++ b/src/main/java/com/fitnesspartner/domain/Users.java
@@ -52,9 +52,6 @@ public class Users extends TimeStamped {
 
 
     public void updateUser(UserUpdateRequestDto userUpdateRequestDto) {
-        if(userUpdateRequestDto.getUsername() != null) {
-            this.username = userUpdateRequestDto.getUsername();
-        }
 
         if(userUpdateRequestDto.getName() != null) {
             this.name = userUpdateRequestDto.getName();

--- a/src/main/java/com/fitnesspartner/dto/users/UserUpdateRequestDto.java
+++ b/src/main/java/com/fitnesspartner/dto/users/UserUpdateRequestDto.java
@@ -6,16 +6,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 public class UserUpdateRequestDto {
-
-    @Size(min = 4, max = 15)
-    private String username;
 
     @Size(min = 2, max = 13)
     private String name;

--- a/src/main/java/com/fitnesspartner/service/UsersService.java
+++ b/src/main/java/com/fitnesspartner/service/UsersService.java
@@ -71,8 +71,6 @@ public class UsersService {
     public UserResponseDto userUpdate(String username, UserUpdateRequestDto userUpdateRequestDto) {
         Users users = findUserByUsernameIfExist(username);
 
-        usernameDuplicateCheck(userUpdateRequestDto.getUsername());
-
         nicknameDuplicateCheck(userUpdateRequestDto.getNickname());
 
         String rawPassword = userUpdateRequestDto.getPassword();

--- a/src/test/java/com/fitnesspartner/service/UsersServiceTest.java
+++ b/src/test/java/com/fitnesspartner/service/UsersServiceTest.java
@@ -97,7 +97,6 @@ class UsersServiceTest {
         void 유저_정보수정() {
             // given
             UserUpdateRequestDto userUpdateRequestDto = new UserUpdateRequestDto(
-                    "nahealthh",
                     "김계란2",
                     "나헬린2",
                     "123456789",
@@ -110,7 +109,6 @@ class UsersServiceTest {
             UserResponseDto userResponseDto = usersService.userUpdate(username, userUpdateRequestDto);
 
             // then
-            assertEquals(userResponseDto.getUsername(), userUpdateRequestDto.getUsername());
             assertEquals(userResponseDto.getName(), userUpdateRequestDto.getName());
             assertEquals(userResponseDto.getNickname(), userResponseDto.getNickname());
             assertEquals(userResponseDto.getEmail(), userResponseDto.getEmail());


### PR DESCRIPTION
## Checklist

- [x] 테스트 코드를 작성하셨나요?
- [x] Exception 처리를 꼼꼼하게 하셨나요?
- [ ] 머지하기 전에 크로스 체크가 되었나요?



## 작업내용

- 유저 정보 수정에서 username 로직 제거
   - JWT 토큰에 username 값이 payload에 저장되고 검증의 용도로 사용되기 때문


## Questions

💬 질문 사항이에요!

🤷‍♂ ️확인 받고 싶은 부분이에요!